### PR TITLE
Add support for ignoring Typescript type-only imports

### DIFF
--- a/packages/skott/README.md
+++ b/packages/skott/README.md
@@ -43,13 +43,14 @@ const { getStructure, findCircularDependencies, findParentsOf, findLeaves } = aw
    */
   includeBaseDir: false,
   /**
-   * (Optional) Whether third-party dependencies (npm) and/or builtin (Node.js core modules) 
-   * should be added in the graph. 
+   * (Optional) Whether third-party dependencies (npm) and/or builtin (Node.js core modules)
+   * should be added in the graph and/or Typescript type-only import should be followed. 
    * Both defaults to `false`.
    */
   dependencyTracking: {
     thirdParty: true,
-    builtin: true
+    builtin: true,
+    typeOnly: true
   };
   /**
    * (Optional) Provide a custom tsconfig file to help skott resolve path aliases.
@@ -236,7 +237,8 @@ const { getStructure } = await skott({
   entrypoint: "lib.js",
   dependencyTracking: {
     builtin: true,
-    thirdParty: true
+    thirdParty: true,
+    typeOnly: true
   }
 });
 

--- a/packages/skott/README.md
+++ b/packages/skott/README.md
@@ -45,7 +45,7 @@ const { getStructure, findCircularDependencies, findParentsOf, findLeaves } = aw
   /**
    * (Optional) Whether third-party dependencies (npm) and/or builtin (Node.js core modules)
    * should be added in the graph and/or Typescript type-only import should be followed. 
-   * Both defaults to `false`.
+   * Defaults to `thirdParty=false`, `builtin=false`, and `typeOnly=true`.
    */
   dependencyTracking: {
     thirdParty: true,

--- a/packages/skott/bin/cli.ts
+++ b/packages/skott/bin/cli.ts
@@ -76,7 +76,7 @@ const cli = sade("skott [entrypoint]", true)
   )
 
   .option(
-    "-n, --trackTypeOnlyDependencies",
+    "-it, --trackTypeOnlyDependencies",
     "Enable dependency tracking for Typescript 'import type' statements",
     true
   )

--- a/packages/skott/bin/cli.ts
+++ b/packages/skott/bin/cli.ts
@@ -76,6 +76,12 @@ const cli = sade("skott [entrypoint]", true)
   )
 
   .option(
+    "-n, --trackTypeOnlyDependencies",
+    "Enable dependency tracking for Typescript 'import type' statements",
+    true
+  )
+
+  .option(
     "-s, --showCircularDependencies",
     "Show all circular dependencies in the graph",
     false

--- a/packages/skott/bin/main.ts
+++ b/packages/skott/bin/main.ts
@@ -310,6 +310,7 @@ type CliOptions = {
   showCircularDependencies: boolean;
   trackThirdPartyDependencies: boolean;
   trackBuiltinDependencies: boolean;
+  trackTypeOnlyDependencies: boolean;
   fileExtensions: string;
   tsconfig: string;
 };
@@ -343,7 +344,8 @@ export async function displaySkott(
     includeBaseDir: options.includeBaseDir,
     dependencyTracking: {
       thirdParty: options.trackThirdPartyDependencies,
-      builtin: options.trackBuiltinDependencies
+      builtin: options.trackBuiltinDependencies,
+      typeOnly: options.trackTypeOnlyDependencies
     },
     fileExtensions: options.fileExtensions
       .split(",")

--- a/packages/skott/src/modules/walkers/common.ts
+++ b/packages/skott/src/modules/walkers/common.ts
@@ -1,7 +1,4 @@
-import {
-  JavaScriptModuleWalker,
-  TypeScriptModuleWalker
-} from "./ecmascript/index.js";
+import { JavaScriptModuleWalker, TypeScriptModuleWalker } from "./ecmascript";
 import { isTypeScriptModule } from "./ecmascript/module-resolver.js";
 
 export interface ModuleWalkerResult {
@@ -9,8 +6,15 @@ export interface ModuleWalkerResult {
 }
 
 export interface ModuleWalker {
-  walk(fileContent: string): Promise<ModuleWalkerResult>;
+  walk(
+    fileContent: string,
+    config: ModuleWalkerConfig
+  ): Promise<ModuleWalkerResult>;
 }
+
+export type ModuleWalkerConfig = {
+  trackTypeOnlyDependencies: boolean;
+};
 
 type Walkers = "JS" | "TS";
 

--- a/packages/skott/src/modules/walkers/common.ts
+++ b/packages/skott/src/modules/walkers/common.ts
@@ -1,4 +1,7 @@
-import { JavaScriptModuleWalker, TypeScriptModuleWalker } from "./ecmascript";
+import {
+  JavaScriptModuleWalker,
+  TypeScriptModuleWalker
+} from "./ecmascript/index.js";
 import { isTypeScriptModule } from "./ecmascript/module-resolver.js";
 
 export interface ModuleWalkerResult {

--- a/packages/skott/src/modules/walkers/ecmascript/module-declaration.ts
+++ b/packages/skott/src/modules/walkers/ecmascript/module-declaration.ts
@@ -39,7 +39,8 @@ function isEcmaScriptModuleDeclaration(estreeNode: any): boolean {
 
 export function extractModuleDeclarations(
   node: any,
-  moduleDeclarations: Set<string>
+  moduleDeclarations: Set<string>,
+  trackTypeOnlyDependencies = true
 ): void {
   if (isCommonJSModuleImport(node)) {
     /**
@@ -54,7 +55,9 @@ export function extractModuleDeclarations(
   }
 
   if (isEcmaScriptModuleDeclaration(node)) {
-    moduleDeclarations.add(node.source.value);
+    if (node.importKind !== "type" || trackTypeOnlyDependencies) {
+      moduleDeclarations.add(node.source.value);
+    }
   }
 
   if (node.type === "ImportExpression") {

--- a/packages/skott/src/modules/walkers/ecmascript/typescript/walker.ts
+++ b/packages/skott/src/modules/walkers/ecmascript/typescript/walker.ts
@@ -1,6 +1,10 @@
 import { walk } from "estree-walker";
 
-import { ModuleWalker, ModuleWalkerResult } from "../../common.js";
+import {
+  ModuleWalker,
+  ModuleWalkerConfig,
+  ModuleWalkerResult
+} from "../../common.js";
 import { extractModuleDeclarations } from "../module-declaration.js";
 
 async function tryOrElse(
@@ -19,8 +23,12 @@ async function tryOrElse(
 }
 
 export class TypeScriptModuleWalker implements ModuleWalker {
-  public async walk(fileContent: string): Promise<ModuleWalkerResult> {
+  public async walk(
+    fileContent: string,
+    config: ModuleWalkerConfig
+  ): Promise<ModuleWalkerResult> {
     const { parse } = await import("@typescript-eslint/typescript-estree");
+    const trackTypeOnlyDependencies = config.trackTypeOnlyDependencies;
     const moduleDeclarations = new Set<string>();
     let jsxEnabled = true;
 
@@ -34,7 +42,11 @@ export class TypeScriptModuleWalker implements ModuleWalker {
 
       walk(isRootNode ? node.body : node, {
         enter(node) {
-          extractModuleDeclarations(node, moduleDeclarations);
+          extractModuleDeclarations(
+            node,
+            moduleDeclarations,
+            trackTypeOnlyDependencies
+          );
         }
       });
     }

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -34,6 +34,7 @@ export interface SkottConfig {
   dependencyTracking: {
     thirdParty: boolean;
     builtin: boolean;
+    typeOnly: boolean;
   };
   fileExtensions: string[];
   tsConfigPath: string;
@@ -58,7 +59,8 @@ const defaultConfig = {
   circularMaxDepth: Number.POSITIVE_INFINITY,
   dependencyTracking: {
     thirdParty: false,
-    builtin: false
+    builtin: false,
+    typeOnly: true
   },
   fileExtensions: [...kExpectedModuleExtensions],
   tsConfigPath: "tsconfig.json"
@@ -112,7 +114,7 @@ export class Skott {
 
     /**
      * If we can't create a node path without the base directory name,
-     * it probably means that the initial node path is located in an higher scope
+     * it probably means that the initial node path is located in a higher scope
      * than the base directory name.
      * Example:
      * Say we have the following file "lib/feature/index.js" with the following
@@ -159,7 +161,13 @@ export class Skott {
     fileContent: string
   ): Promise<Set<string>> {
     const moduleWalker = selectAppropriateModuleWalker(fileName);
-    const { moduleDeclarations } = await moduleWalker.walk(fileContent);
+    const moduleWalkerConfig = {
+      trackTypeOnlyDependencies: this.config.dependencyTracking.typeOnly
+    };
+    const { moduleDeclarations } = await moduleWalker.walk(
+      fileContent,
+      moduleWalkerConfig
+    );
 
     return moduleDeclarations;
   }

--- a/packages/skott/test/ecmascript/graph.spec.ts
+++ b/packages/skott/test/ecmascript/graph.spec.ts
@@ -48,7 +48,8 @@ async function makeSkott(
       includeBaseDir,
       dependencyTracking: {
         thirdParty: true,
-        builtin: true
+        builtin: true,
+        typeOnly: true
       },
       fileExtensions: [".js", ".ts"],
       tsConfigPath: "./tsconfig.json"
@@ -108,7 +109,8 @@ describe("When building the project structure independently of JavaScript or Typ
           includeBaseDir: false,
           dependencyTracking: {
             thirdParty: false,
-            builtin: false
+            builtin: false,
+            typeOnly: true
           },
           fileExtensions: [".js"],
           tsConfigPath: "./tsconfig.json"

--- a/packages/skott/test/ecmascript/shared.ts
+++ b/packages/skott/test/ecmascript/shared.ts
@@ -56,13 +56,15 @@ type UnwrappedSkottStructure = {
 export async function buildSkottProjectUsingInMemoryFileExplorer({
   entrypoint,
   includeBaseDir = false,
-  thirdParty = false,
+  trackThirdParty = false,
+  trackTypeOnly = true,
   fileExtensions = [...kExpectedModuleExtensions],
   tsConfigPath = "./tsconfig.json"
 }: {
   entrypoint?: string;
   includeBaseDir?: boolean;
-  thirdParty?: boolean;
+  trackThirdParty?: boolean;
+  trackTypeOnly?: boolean;
   fileExtensions?: string[];
   tsConfigPath?: string;
 } = {}): Promise<UnwrappedSkottStructure> {
@@ -72,8 +74,9 @@ export async function buildSkottProjectUsingInMemoryFileExplorer({
       circularMaxDepth: Number.POSITIVE_INFINITY,
       includeBaseDir,
       dependencyTracking: {
-        thirdParty,
-        builtin: false
+        thirdParty: trackThirdParty,
+        builtin: false,
+        typeOnly: trackTypeOnly
       },
       fileExtensions,
       tsConfigPath

--- a/packages/skott/test/ecmascript/typescript.spec.ts
+++ b/packages/skott/test/ecmascript/typescript.spec.ts
@@ -99,37 +99,71 @@ describe("When traversing a TypeScript project", () => {
       });
 
       describe("When the file includes type imports", () => {
-        it("skott should build the graph with two nodes and one link", async () => {
-          // Forcing files to add specific TS syntax
-          mountFakeFileSystem({
-            "index.ts": `
-                import type { Foo } from "./foo";
-  
-                const someTypeScriptSpecificStuff: number = 10;
-                console.log(foo.doSomething());
-            `,
-            "foo.ts": `
-                export type Foo = {
-                    doSomething: () => stng;
-                }
-            `
-          });
+        describe("When type imports are taken into account", () => {
+          it("skott should build the graph with two nodes and one link", async () => {
+            // Forcing files to add specific TS syntax
+            mountFakeFileSystem({
+              "index.ts": `
+                  import type { Foo } from "./foo";
+    
+                  const someTypeScriptSpecificStuff: number = 10;
+                  console.log(foo.doSomething());
+              `,
+              "foo.ts": `
+                  export type Foo = {
+                      doSomething: () => stng;
+                  }
+              `
+            });
 
-          const { graph } = await buildSkottProjectUsingInMemoryFileExplorer({
-            entrypoint: "index.ts"
-          });
+            const { graph } = await buildSkottProjectUsingInMemoryFileExplorer({
+              entrypoint: "index.ts"
+            });
 
-          expect(graph).to.be.deep.equal({
-            "index.ts": {
-              adjacentTo: ["foo.ts"],
-              id: "index.ts",
-              body: fakeNodeBody
-            },
-            "foo.ts": {
-              adjacentTo: [],
-              id: "foo.ts",
-              body: fakeNodeBody
-            }
+            expect(graph).to.be.deep.equal({
+              "index.ts": {
+                adjacentTo: ["foo.ts"],
+                id: "index.ts",
+                body: fakeNodeBody
+              },
+              "foo.ts": {
+                adjacentTo: [],
+                id: "foo.ts",
+                body: fakeNodeBody
+              }
+            });
+          });
+        });
+
+        describe("When type imports are ignored", () => {
+          it("skott should build the graph with only the root node", async () => {
+            // Forcing files to add specific TS syntax
+            mountFakeFileSystem({
+              "index.ts": `
+                  import type { Foo } from "./foo";
+    
+                  const someTypeScriptSpecificStuff: number = 10;
+                  console.log(foo.doSomething());
+              `,
+              "foo.ts": `
+                  export type Foo = {
+                      doSomething: () => stng;
+                  }
+              `
+            });
+
+            const { graph } = await buildSkottProjectUsingInMemoryFileExplorer({
+              entrypoint: "index.ts",
+              trackTypeOnly: false
+            });
+
+            expect(graph).to.be.deep.equal({
+              "index.ts": {
+                adjacentTo: [],
+                id: "index.ts",
+                body: fakeNodeBody
+              }
+            });
           });
         });
       });
@@ -196,7 +230,7 @@ describe("When traversing a TypeScript project", () => {
             const { graph } = await buildSkottProjectUsingInMemoryFileExplorer({
               entrypoint: "index.ts",
               includeBaseDir: false,
-              thirdParty: true
+              trackThirdParty: true
             });
 
             expect(graph).to.be.deep.equal({
@@ -241,7 +275,7 @@ describe("When traversing a TypeScript project", () => {
             const { graph } = await buildSkottProjectUsingInMemoryFileExplorer({
               entrypoint: "index.ts",
               includeBaseDir: false,
-              thirdParty: true
+              trackThirdParty: true
             });
 
             expect(graph).to.be.deep.equal({
@@ -297,7 +331,7 @@ describe("When traversing a TypeScript project", () => {
             const { graph } = await buildSkottProjectUsingInMemoryFileExplorer({
               entrypoint: "index.ts",
               includeBaseDir: false,
-              thirdParty: true
+              trackThirdParty: true
             });
 
             expect(graph).to.be.deep.equal({
@@ -374,7 +408,7 @@ describe("When traversing a TypeScript project", () => {
           });
 
           const { graph } = await buildSkottProjectUsingInMemoryFileExplorer({
-            thirdParty: true
+            trackThirdParty: true
           });
 
           expect(graph).to.be.deep.equal({
@@ -444,7 +478,7 @@ describe("When traversing a TypeScript project", () => {
           });
 
           const { graph } = await buildSkottProjectUsingInMemoryFileExplorer({
-            thirdParty: true,
+            trackThirdParty: true,
             tsConfigPath: "tsconfig.build.json"
           });
 


### PR DESCRIPTION
It's not a problem if such imports cause dependency cycles, so I'd like to ignore them when using findCircularDependencies.