### PR TITLE
fix: ignore file names with leading dot by default when using ignore pattern

### DIFF
--- a/.changeset/dirty-adults-repeat.md
+++ b/.changeset/dirty-adults-repeat.md
@@ -1,0 +1,5 @@
+---
+"skott": patch
+---
+
+Ignore files with leading dots by default when using ignore patterns

--- a/packages/skott/test/unit/runner.spec.ts
+++ b/packages/skott/test/unit/runner.spec.ts
@@ -184,6 +184,30 @@ describe("Skott analysis runner", () => {
           "src/apps/app1/src/index.ts"
         ]);
       });
+
+      test("Should ignore files with special names", async () => {
+        mountFakeFileSystem({
+          "./src/apps/app1/src/feature.ts": ``,
+          "./src/config/.eslintrc.js": ``
+        });
+
+        const skott = new Skott(
+          defaultConfig,
+          new InMemoryFileReader({
+            cwd: "./",
+            ignorePattern: "src/config/**/*"
+          }),
+          new InMemoryFileWriter(),
+          new ModuleWalkerSelector(),
+          new FakeLogger()
+        );
+
+        const { files } = await skott
+          .initialize()
+          .then(({ getStructure }) => getStructure());
+
+        expect(files).toEqual(["src/apps/app1/src/feature.ts"]);
+      });
     });
 
     describe("When using bulk analysis with imports between files", () => {


### PR DESCRIPTION
discards `.eslintrc.js` like files when the ignore pattern target `.js` files (or parent directory)