### PR TITLE
fix: (#84) compute aliases even if entry file is not typescript file

### DIFF
--- a/.changeset/calm-boats-shake.md
+++ b/.changeset/calm-boats-shake.md
@@ -1,0 +1,5 @@
+---
+"skott": patch
+---
+
+Skott now read Typescript aliases when the entrypoint is not a Typescript file.

--- a/packages/skott/src/modules/resolvers/ecmascript/resolver.ts
+++ b/packages/skott/src/modules/resolvers/ecmascript/resolver.ts
@@ -15,8 +15,11 @@ import {
   DependencyResolverOptions,
   kExpectedModuleExtensions
 } from "../base-resolver.js";
+import { FileReaderTag } from "../../../filesystem/file-reader.js";
 
 import * as Option from "@effect/data/Option";
+import {pipe} from "@effect/data/Function";
+import * as Effect from "@effect/io/Effect";
 
 const NODE_PROTOCOL = "node:";
 
@@ -109,6 +112,16 @@ export function isJavaScriptModule(module: string): boolean {
     extension === ".jsx" ||
     extension === ".mjs" ||
     extension === ".cjs"
+  );
+}
+
+export function isTypeScriptProject(tsConfigPath: string) {
+  return pipe(
+      Effect.service(FileReaderTag),
+      Effect.flatMap(
+          (fileReader) => Effect.tryPromise(() => fileReader.stats(tsConfigPath))
+      ),
+      Effect.map((fileSize)=> fileSize > 0),
   );
 }
 

--- a/packages/skott/src/modules/resolvers/ecmascript/resolver.ts
+++ b/packages/skott/src/modules/resolvers/ecmascript/resolver.ts
@@ -119,11 +119,10 @@ export function isTypeScriptProject(tsConfigPath: string) {
   return pipe(
       Effect.service(FileReaderTag),
       Effect.flatMap(
-          (fileReader) => Effect.tryPromise(() => fileReader.stats(
+          (fileReader) => Effect.tryPromise(() => fileReader.exists(
               path.join(fileReader.getCurrentWorkingDir(), tsConfigPath))
           )
       ),
-      Effect.map((fileSize)=> fileSize > 0),
   );
 }
 

--- a/packages/skott/src/modules/resolvers/ecmascript/resolver.ts
+++ b/packages/skott/src/modules/resolvers/ecmascript/resolver.ts
@@ -119,7 +119,9 @@ export function isTypeScriptProject(tsConfigPath: string) {
   return pipe(
       Effect.service(FileReaderTag),
       Effect.flatMap(
-          (fileReader) => Effect.tryPromise(() => fileReader.stats(tsConfigPath))
+          (fileReader) => Effect.tryPromise(() => fileReader.stats(
+              path.join(fileReader.getCurrentWorkingDir(), tsConfigPath))
+          )
       ),
       Effect.map((fileSize)=> fileSize > 0),
   );

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -31,7 +31,7 @@ import {
 } from "./modules/resolvers/base-resolver.js";
 import {
   EcmaScriptDependencyResolver,
-  isTypeScriptModule
+  isTypeScriptProject,
 } from "./modules/resolvers/ecmascript/resolver.js";
 import { ModuleWalkerSelector } from "./modules/walkers/common.js";
 import {
@@ -491,7 +491,13 @@ export class Skott<T> {
       Effect.runPromise
     );
 
-    if (isTypeScriptModule(entrypointModulePath)) {
+    const doesTsConfigExist = await pipe(
+        isTypeScriptProject(this.config.tsConfigPath),
+        Effect.provideService(FileReaderTag, this.fileReader),
+        Effect.runPromise
+    );
+
+    if (doesTsConfigExist) {
       const rootTSConfig = await buildPathAliases(
         this.fileReader,
         this.config.tsConfigPath,


### PR DESCRIPTION
As mentionned in [the following conversation](https://github.com/antoine-coulon/skott/issues/84), I removed the `isTypescriptModule(entryPoint)` by `isTypescriptProject()`.
