### PR TITLE
fix: cannot read R_OK from undefined (node < 18.4.0)

### DIFF
--- a/.changeset/tough-cougars-check.md
+++ b/.changeset/tough-cougars-check.md
@@ -1,0 +1,5 @@
+---
+"skott": patch
+---
+
+fsPromises.constants is undefined for node < 18.4.0

--- a/packages/skott/src/filesystem/file-reader.ts
+++ b/packages/skott/src/filesystem/file-reader.ts
@@ -65,7 +65,7 @@ export class FileSystemReader implements FileReader {
 
   exists(filename: string) {
     return fs
-      .access(filename, fs.constants.R_OK)
+      .access(filename, R_OK)
       .then(() => true)
       .catch(() => false);
   }


### PR DESCRIPTION
Not a big change, and depending of the node version skott want to officialy support, you might decide to close this PR, but a recent changes introduces a bug:

Importing R_OK from fs.constants is not supported for node version lower than 18.4.0

Relates to:
https://github.com/nodejs/node/issues/44209#issuecomment-1211639170