### PR TITLE
fix: use localhost instead of 127.0.0.1 to ensure cross platform compatibility when auto opening the web application

### DIFF
--- a/.changeset/quick-shirts-dance.md
+++ b/.changeset/quick-shirts-dance.md
@@ -1,0 +1,5 @@
+---
+"skott": patch
+---
+
+Use localhost instead of 127.0.0.1 to ensure a better cross platform compatibility when auto opening the web application. Thanks @HassanMojab for the hint!

--- a/packages/skott/bin/ui/webapp.ts
+++ b/packages/skott/bin/ui/webapp.ts
@@ -96,7 +96,7 @@ export function openWebApplication(
   srv.listen(process.env.SKOTT_PORT || 0);
 
   // @ts-expect-error - "port" exists
-  const bindedAddress = `http://127.0.0.1:${srv.server?.address()?.port}`;
+  const bindedAddress = `http://localhost:${srv.server?.address()?.port}`;
 
   console.log(
     `\n ${kleur.bold(`💻 Web application is ready:`)} ${kleur


### PR DESCRIPTION
Fixes #107 