### PR TITLE
The `groupBy` feature

### DIFF
--- a/.changeset/soft-ducks-collect.md
+++ b/.changeset/soft-ducks-collect.md
@@ -1,0 +1,7 @@
+---
+"skott": minor
+---
+
+Optional `groupBy` configuration is added - it is a function of `(path: string) => string | undefined` type.
+
+If `groupBy` is provided, then `groupedGraph` will be emitted on `getStructure` call.

--- a/packages/skott/README.md
+++ b/packages/skott/README.md
@@ -101,7 +101,20 @@ const { getStructure, getWorkspace, useGraph, findUnusedDependencies } = await s
    * (Optional) Enable verbose internal logging.
    * Defaults to `false`
    */
-  verbose: true
+  verbose: true,
+  /**
+   *
+   * (Optional) If this function is provided, Skott will build a separate graph of links
+   * between entire groups of modules, which can be later accessed as `groupedGraph` in the
+   * result of `getStructure` call.
+   *
+   */
+  groupBy: (path) => {
+    if (path.includes("core")) return "core";
+    if (path.includes("feature-a")) return "feature-a";
+
+    return undefined;
+  };
 });
 ```
 
@@ -390,6 +403,35 @@ console.log(graph["lib.js"].body);
   thirdPartyDependencies: ["meriyah"], 
   builtinDependencies: ["node:fs"] 
 }
+```
+
+### Explore your architecture
+
+Skott allows you to explore the relationships between parts of your architecture, not just between specific modules.
+
+To do that you need to tell Skott, how exactly modules in your project are combined into a architecture blocks - use `groupBy` API for that:
+
+
+```typescript
+const instance = await skott({
+  groupBy: (path) => {
+    if (path.includes("src/core")) return "core";
+    if (path.includes("src/feature-a")) return "feature-a";
+
+    // ... other conditions
+
+    // if no match
+    return undefined;
+  }
+});
+
+const { groupedGraph } = instance.getStructure();
+
+groupedGraph["core"];
+// { id: "core", adjacentTo: [], body: { size, files, ... } }
+
+groupedGraph["feature-a"];
+// { id: "feature-a", adjacentTo: ["core", ...], body: { size, files, ... } }
 ```
 
 ### Explore workspace content

--- a/packages/skott/src/config.ts
+++ b/packages/skott/src/config.ts
@@ -14,6 +14,20 @@ function withDefaultValue<T>(defaultValue: T) {
   };
 }
 
+const decodeGroupBy: D.Decoder<unknown, (input: string) => string | undefined> =
+  {
+    // Typecast is ok here as we can't really runtime-check (before any calls) that the provided function
+    // will always return a valid value anyawy
+    // Separate runtime checks will be done during the actual usage of the function for each call
+    decode: (input) =>
+      typeof input === "function"
+        ? D.success(input as (input: string) => string | undefined)
+        : D.failure(
+            input,
+            "`groupBy` must be a function or not provided at all"
+          )
+  };
+
 const config = D.struct({
   entrypoint: withDefaultValue(defaultConfig.entrypoint)(D.string),
   includeBaseDir: withDefaultValue(defaultConfig.includeBaseDir)(D.boolean),
@@ -34,6 +48,7 @@ const config = D.struct({
   dependencyResolvers: withDefaultValue(defaultConfig.dependencyResolvers)(
     D.array(dependencyResolverDecoder())
   ),
+  groupBy: withDefaultValue(defaultConfig.groupBy)(decodeGroupBy),
   /**
    * External runner only config
    */

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -73,6 +73,10 @@ export interface SkottConfig<T> {
 
 export interface SkottStructure<T = unknown> {
   graph: Record<string, SkottNode<T>>;
+  /**
+   * If `groupBy` is provided in the configuration, this will be available as a graph of links between groups of modules.
+   */
+  groupedGraph?: Record<string, string[]>;
   files: string[];
 }
 

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -547,7 +547,6 @@ export class Skott<T> {
          * - the file to the group
          * - the size of the new node
          * - built-in and third-party dependencies
-         * - the links between groups
          */
         this.#groupedGraph!.mergeVertexBody(group, (groupBody) => {
           if (groupBody.files.includes(node.id)) return;

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -70,9 +70,26 @@ export interface SkottConfig<T> {
    *
    * @example
    * ```
-   * const instance = await skott({ groupBy: (path) => ... })
+   * const instance = await skott({
+   *  groupBy: (path) => {
    *
-   * instance.getStructure().groupedGraph
+   *   if (path.includes("core")) return "core";
+   *   if (path.includes("feature-a")) return "feature-a";
+   *
+   *   // ... other conditions
+   *
+   *   // if no match
+   *   return undefined;
+   *  }
+   * })
+   *
+   * const {groupedGraph} = instance.getStructure();
+   *
+   * groupedGraph["core"]
+   * // { id: "core", adjacentTo, body: { size, files, ... } }
+   *
+   * groupedGraph["feature-a"]
+   * // { id: "feature-a", adjacentTo, body: { size, files, ... } }
    *
    * ```
    */

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -67,6 +67,14 @@ export interface SkottConfig<T> {
    *
    * @param path - The path of the module, e.g. `rootDir/src/feature-a/index.js`
    * @returns - The group name, e.g. `Feature A` OR `undefined` if the module should not be included in any group.
+   *
+   * @example
+   * ```
+   * const instance = await skott({ groupBy: (path) => ... })
+   *
+   * instance.getStructure().groupedGraph
+   *
+   * ```
    */
   groupBy?: (path: string) => string | undefined;
 }

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -60,6 +60,15 @@ export interface SkottConfig<T> {
   incremental: boolean;
   manifestPath: string;
   tsConfigPath: string;
+  /**
+   *
+   * If this function is provided, Skott will build a separate graph of links between entire groups of modules.
+   * This is useful if you would rather see links between large architectural blocks than between specific modules within those blocks.
+   *
+   * @param path - The path of the module, e.g. `rootDir/src/feature-a/index.js`
+   * @returns - The group name, e.g. `Feature A` OR `undefined` if the module should not be included in any group.
+   */
+  groupBy?: (path: string) => string | undefined;
 }
 
 export interface SkottStructure<T = unknown> {

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -99,7 +99,7 @@ export interface SkottInstance<T = unknown> {
   ) => Promise<UnusedDependencies>;
 }
 
-export const defaultConfig = {
+export const defaultConfig: SkottConfig<unknown> = {
   entrypoint: "",
   circularMaxDepth: Number.POSITIVE_INFINITY,
   dependencyResolvers: [new EcmaScriptDependencyResolver()],
@@ -112,7 +112,8 @@ export const defaultConfig = {
   includeBaseDir: false,
   incremental: false,
   manifestPath: "package.json",
-  tsConfigPath: "tsconfig.json"
+  tsConfigPath: "tsconfig.json",
+  groupBy: undefined
 };
 
 export interface WorkspaceConfiguration {

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -525,7 +525,7 @@ export class Skott<T> {
     }
 
     throw new Error(
-      `GroupBy function must return a string or undefined, but returned ${result}`
+      `groupBy function must return a string or undefined, but returned "${result}" (for "${nodePath}")`
     );
   }
 

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -611,11 +611,11 @@ export class Skott<T> {
        */
       node.adjacentTo.forEach((adjacentNodeId) => {
         const group = this.getValidGroup(node.id);
-        const adjacentGroup = this.getValidGroup(adjacentNode);
+        const adjacentGroup = this.getValidGroup(adjacentNodeId);
 
         if (group && adjacentGroup && group !== adjacentGroup) {
           /** Ensure that "to" target exsists */
-          this.addNodeToGroupedGraph(projectStructure[adjacentNode]);
+          this.addNodeToGroupedGraph(projectStructure[adjacentNodeId]);
 
           this.#groupedGraph!.addEdge({
             from: group,

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -615,7 +615,7 @@ export class Skott<T> {
       /**
        * Update edges
        */
-      node.adjacentTo.forEach((adjacentNode) => {
+      node.adjacentTo.forEach((adjacentNodeId) => {
         const group = this.getValidGroup(node.id);
         const adjacentGroup = this.getValidGroup(adjacentNode);
 

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -529,13 +529,7 @@ export class Skott<T> {
   }
 
   private getValidGroup(nodePath: string) {
-    if (!this.config.groupBy) {
-      throw new Error(
-        "Grouped graph can't be built without a groupBy function in the configuration"
-      );
-    }
-
-    const result = this.config.groupBy(nodePath);
+    const result = this.config.groupBy!(nodePath);
 
     if (typeof result === "string" || !result) {
       return result;

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -12,7 +12,7 @@ import {
 import { FileReader } from "./filesystem/file-reader.js";
 import type { FileWriter } from "./filesystem/file-writer.js";
 import { toUnixPathLike } from "./filesystem/path.js";
-import type { SkottNode, SkottNodeBody } from "./graph/node.js";
+import type { SkottNode } from "./graph/node.js";
 import { type TraversalApi, makeTraversalApi } from "./graph/traversal.js";
 import {
   highlight,
@@ -544,14 +544,6 @@ export class Skott<T> {
     const group = this.getValidGroup(node.id);
 
     if (group) {
-      /**
-       * Typecast is ok here:
-       * current typings are expecting SkottNodeBody + other arbitary values if available, but currently TS is not happy with it.
-       *
-       * The SkottNode type should be described in some other way to properly support that, but SkottNodeBody is avaiable at the runtime anyway.
-       */
-      const nodeBody = node.body as SkottNodeBody;
-
       if (this.#groupedGraph!.hasVertex(group)) {
         /**
          * Group vertex already exists, we need to add up:
@@ -564,15 +556,15 @@ export class Skott<T> {
 
           groupBody.files.push(node.id);
 
-          groupBody.size += nodeBody.size;
+          groupBody.size += node.body.size;
 
-          nodeBody.thirdPartyDependencies.forEach((dep) => {
+          node.body.thirdPartyDependencies.forEach((dep) => {
             if (!groupBody.thirdPartyDependencies.includes(dep)) {
               groupBody.thirdPartyDependencies.push(dep);
             }
           });
 
-          nodeBody.builtinDependencies.forEach((dep) => {
+          node.body.builtinDependencies.forEach((dep) => {
             if (!groupBody.builtinDependencies.includes(dep)) {
               groupBody.builtinDependencies.push(dep);
             }
@@ -588,10 +580,10 @@ export class Skott<T> {
           id: group,
           adjacentTo: [],
           body: {
-            size: nodeBody.size,
+            size: node.body.size,
             files: [node.id],
-            thirdPartyDependencies: [...nodeBody.thirdPartyDependencies],
-            builtinDependencies: [...nodeBody.builtinDependencies]
+            thirdPartyDependencies: [...node.body.thirdPartyDependencies],
+            builtinDependencies: [...node.body.builtinDependencies]
           }
         });
       }

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -605,7 +605,7 @@ export class Skott<T> {
         const group = this.getValidGroup(node.id);
         const adjacentGroup = this.getValidGroup(adjacentNodeId);
 
-        if (group && adjacentGroup && group !== adjacentGroup) {
+        if (group && adjacentGroup) {
           /** Ensure that "to" target exsists */
           this.addNodeToGroupedGraph(projectStructure[adjacentNodeId]);
 

--- a/packages/skott/test/integration/api.spec.ts
+++ b/packages/skott/test/integration/api.spec.ts
@@ -44,6 +44,27 @@ describe("When running Skott using all real dependencies", () => {
         "Illegal configuration: `cwd` can't be customized when providing an entrypoint"
       );
     });
+
+    describe("groupBy", () => {
+      test("Should not allow `groupBy` to be a non-function", async () => {
+        await expect(() =>
+          skott({
+            // @ts-expect-error
+            groupBy: "not-a-function"
+          })
+        ).rejects.toThrow(
+          "`groupBy` must be a function or not provided at all"
+        );
+      });
+
+      test("Should allow `groupBy` to be a function", async () => {
+        const skottInstance = await skott({
+          groupBy: (_path) => "group"
+        });
+
+        expect(skottInstance).toBeDefined();
+      });
+    });
   });
 
   describe("When traversing files", () => {

--- a/packages/skott/test/integration/api.spec.ts
+++ b/packages/skott/test/integration/api.spec.ts
@@ -354,10 +354,51 @@ describe("When running Skott using all real dependencies", () => {
             .then(({ getStructure }) => getStructure());
 
           expect(groupedGraph).toEqual({
-            core: {},
-            "feature-a": {},
-            "feature-b": {},
-            "feature-c": {}
+            core: {
+              id: "core",
+              adjacentTo: [],
+              body: {
+                size: 20,
+                files: ["skott-ignore-temp-fs/src/core/index.js"],
+                thirdPartyDependencies: [],
+                builtinDependencies: []
+              }
+            },
+            "feature-a": {
+              id: "feature-a",
+              adjacentTo: ["core"],
+              body: {
+                size: 51,
+                files: ["skott-ignore-temp-fs/src/features/feature-a/index.js"],
+                thirdPartyDependencies: [],
+                builtinDependencies: []
+              }
+            },
+            "feature-b": {
+              id: "feature-b",
+              adjacentTo: ["core", "feature-a"],
+              body: {
+                size: 101,
+                files: ["skott-ignore-temp-fs/src/features/feature-b/index.js"],
+                thirdPartyDependencies: [],
+                builtinDependencies: []
+              }
+            },
+            "feature-c": {
+              id: "feature-c",
+              adjacentTo: ["core", "feature-a", "feature-b"],
+              body: {
+                size: 261,
+                files: [
+                  "skott-ignore-temp-fs/src/features/feature-c/index.js",
+                  "skott-ignore-temp-fs/src/features/feature-c/c.js",
+                  "skott-ignore-temp-fs/src/features/feature-c/a.js",
+                  "skott-ignore-temp-fs/src/features/feature-c/b.js"
+                ],
+                thirdPartyDependencies: [],
+                builtinDependencies: []
+              }
+            }
           });
         });
       });


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 2: In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     If you already described the problem in some issue, no need to repeat here,
     you can add the magic phrase "Fixes #1234" to automatically link and close 
     the issue #1234 when your PR is merged.
--------------------------------------------------------------------------->


This PR adds the first part for "grouped graph" feature, as discussed in #125 :
- Optional `groupBy` configuration is added - it is a function of `(path: string) => string | undefined` type
- If `groupBy` is provided, then `groupedGraph` will be emitted on `getStructure` call

### Example

```typescript
const instance = await skott({
 groupBy: (path) => {
          if (path.includes("src/core")) return "core";
          if (path.includes("src/features/feature-a")) return "feature-a";
          
          return undefined;
      }
  }
});

const {groupedGraph} = instance.getStructure();

groupedGraph.core // { id: "core", adjacentTo, body: { size, files, ... } }
groupedGraph["feature-a"] // { id: "feature-a", adjacentTo, body: { size, files, ... } }
```

## Implementation

<!--------------------------------------------------------------------------
👉 STEP 3: Provide additional details about your fix or feature:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

As was discussed in the issue, there is a single `groupBy` function, which assigns module to a group based on its `node.id` (which is the path of the module location).

Under the hood it is the separate graph, which is built in the moment of `getStructure` call, using the original graph of project structure as a source of truth.

## Testing

<!--------------------------------------------------------------------------
👉 STEP 4: What test cases did you use to validate your work? Did you write unit or
    integration tests?
--------------------------------------------------------------------------->

Integration tests in the `integration/api.spec.ts`

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 5: skott is using changesets so if this PR introduces a new behavior or fixes a bug 
    a changeset should be generated using `pnpm changeset` at the root of the workspace.
--------------------------------------------------------------------------->

The changeset is generated and the JSDoc comment is added to the `groupBy` field, also documentation is added into `skott/README.md`

- [x] Changesets were generated using `pnpm changeset` at the root of the workspace, affected packages are being bumped (either patch/minor) and a clear description for each of the affected packages was added.