### PR TITLE
fix: use lazily evaluated process.cwd as a default config value

### DIFF
--- a/.changeset/metal-pumas-wait.md
+++ b/.changeset/metal-pumas-wait.md
@@ -1,0 +1,22 @@
+---
+"skott": patch
+---
+
+This patch fixes the eager evaluation of `cwd` default value from the config preventing [process.chdir](https://nodejs.org/api/process.html#processchdirdirectory) 
+to work as expected when used before invoking skott's API.
+
+```js
+process.chdir('/tmp/somewhere');
+
+// skott is now being executed at the root of "/tmp/somewhere"
+
+const instance = await skott();
+```
+
+Note: regarding the generated graph relationships, this is pretty much equivalent as doing `skott({ cwd: "/tmp/somewhere" })`, even though
+node paths will be relative and won't have the same values as the later still executes skott from the script location 
+and not from `/tmp/somewhere`. In other words, using `cwd` parameter will have node paths being relative to skott's script location, while using
+`process.chdir` will make skott execute the script from the provided directory.
+
+You can find a real example of the difference between node paths using `process.chdir` and `cwd`: https://github.com/antoine-coulon/skott/issues/149#issuecomment-1989451725 
+by @mattkindy.

--- a/packages/skott/src/config.ts
+++ b/packages/skott/src/config.ts
@@ -28,34 +28,37 @@ const decodeGroupBy: D.Decoder<unknown, (input: string) => string | undefined> =
           )
   };
 
-const config = D.struct({
-  entrypoint: withDefaultValue(defaultConfig.entrypoint)(D.string),
-  includeBaseDir: withDefaultValue(defaultConfig.includeBaseDir)(D.boolean),
-  incremental: withDefaultValue(defaultConfig.incremental)(D.boolean),
-  circularMaxDepth: withDefaultValue(defaultConfig.circularMaxDepth)(D.number),
-  dependencyTracking: withDefaultValue(defaultConfig.dependencyTracking)(
-    D.struct({
-      thirdParty: D.boolean,
-      builtin: D.boolean,
-      typeOnly: D.boolean
-    })
-  ),
-  fileExtensions: withDefaultValue(defaultConfig.fileExtensions)(
-    D.array(D.literal(".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"))
-  ),
-  tsConfigPath: withDefaultValue(defaultConfig.tsConfigPath)(D.string),
-  manifestPath: withDefaultValue(defaultConfig.manifestPath)(D.string),
-  dependencyResolvers: withDefaultValue(defaultConfig.dependencyResolvers)(
-    D.array(dependencyResolverDecoder())
-  ),
-  groupBy: withDefaultValue(defaultConfig.groupBy)(decodeGroupBy),
-  /**
-   * External runner only config
-   */
-  cwd: withDefaultValue(process.cwd())(D.string),
-  verbose: withDefaultValue(false)(D.boolean),
-  ignorePattern: withDefaultValue("")(D.string)
-});
+const getConfig = () =>
+  D.struct({
+    entrypoint: withDefaultValue(defaultConfig.entrypoint)(D.string),
+    includeBaseDir: withDefaultValue(defaultConfig.includeBaseDir)(D.boolean),
+    incremental: withDefaultValue(defaultConfig.incremental)(D.boolean),
+    circularMaxDepth: withDefaultValue(defaultConfig.circularMaxDepth)(
+      D.number
+    ),
+    dependencyTracking: withDefaultValue(defaultConfig.dependencyTracking)(
+      D.struct({
+        thirdParty: D.boolean,
+        builtin: D.boolean,
+        typeOnly: D.boolean
+      })
+    ),
+    fileExtensions: withDefaultValue(defaultConfig.fileExtensions)(
+      D.array(D.literal(".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"))
+    ),
+    tsConfigPath: withDefaultValue(defaultConfig.tsConfigPath)(D.string),
+    manifestPath: withDefaultValue(defaultConfig.manifestPath)(D.string),
+    dependencyResolvers: withDefaultValue(defaultConfig.dependencyResolvers)(
+      D.array(dependencyResolverDecoder())
+    ),
+    groupBy: withDefaultValue(defaultConfig.groupBy)(decodeGroupBy),
+    /**
+     * External runner only config
+     */
+    cwd: withDefaultValue(process.cwd())(D.string),
+    verbose: withDefaultValue(false)(D.boolean),
+    ignorePattern: withDefaultValue("")(D.string)
+  });
 
 export function decodeInputConfig<T>(
   partialConfig: Option.Option<Partial<SkottConfig<T>>>
@@ -63,7 +66,7 @@ export function decodeInputConfig<T>(
   return pipe(
     partialConfig,
     Option.getOrNull,
-    config.decode,
+    getConfig().decode,
     E.fold((decodeError) => {
       throw new Error(`Invalid Skott config. Reason: ${D.draw(decodeError)}`);
     }, identity)


### PR DESCRIPTION
fixes parts of #149 