### PR TITLE
fix: when a cwd is provided without an entrypoint, allow tsconfig to be omitted

### DIFF
--- a/.changeset/fresh-lamps-rescue.md
+++ b/.changeset/fresh-lamps-rescue.md
@@ -1,0 +1,5 @@
+---
+"skott": patch
+---
+
+allow tsconfig to be omitted when only a directory is provided

--- a/packages/skott/src/skott.ts
+++ b/packages/skott/src/skott.ts
@@ -694,13 +694,21 @@ export class Skott<T> {
   }
 
   private async buildFromRootDirectory(): Promise<void> {
-    const rootTSConfig = await buildPathAliases(
-      this.fileReader,
-      this.config.tsConfigPath,
-      this.#workspaceConfiguration.pathAliases,
-      this.logger
+    const doesTsConfigExist = await pipe(
+      isTypeScriptProject(this.config.tsConfigPath),
+      Effect.provideService(FileReader, this.fileReader),
+      Effect.runPromise
     );
-    this.#workspaceConfiguration.typescript = rootTSConfig;
+
+    if (doesTsConfigExist) {
+      const rootTSConfig = await buildPathAliases(
+        this.fileReader,
+        this.config.tsConfigPath,
+        this.#workspaceConfiguration.pathAliases,
+        this.logger
+      );
+      this.#workspaceConfiguration.typescript = rootTSConfig;
+    }
 
     for await (const rootFile of this.fileReader.readdir(
       this.fileReader.getCurrentWorkingDir(),


### PR DESCRIPTION
## Summary

A tsconfig path is not required when an entrypoint is provided, but the same should be true if only a `cwd` is provided. I wanted to run skott against a directory only containing js files but it was expecting a tsconfig to be passed in.

## Implementation

I borrowed the definition of `doesTsConfigExist` from `buildFromEntrypoint` and applied it in `buildFromRootDirectory`.

## Testing

<!--------------------------------------------------------------------------
👉 STEP 4: What test cases did you use to validate your work? Did you write unit or
    integration tests?
--------------------------------------------------------------------------->

- [ ] Unit tests were added to cover the new feature or bug fix (+ eventually integration tests, but unit should be preferred whenever its possible).

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 5: skott is using changesets so if this PR introduces a new behavior or fixes a bug 
    a changeset should be generated using `pnpm changeset` at the root of the workspace.
--------------------------------------------------------------------------->

- [x] Changesets were generated using `pnpm changeset` at the root of the workspace, affected packages are being bumped (either patch/minor) and a clear description for each of the affected packages was added.
