### PR TITLE
feat: option to highlight "Deep dependencies" when clicking on source files

### DIFF
--- a/.changeset/clean-turkeys-confess.md
+++ b/.changeset/clean-turkeys-confess.md
@@ -1,0 +1,5 @@
+---
+"skott-webapp": minor
+---
+
+Add option to highlight "Deep dependencies" when clicking on source files

--- a/apps/web/src/core/boostrap-app.spec.ts
+++ b/apps/web/src/core/boostrap-app.spec.ts
@@ -88,6 +88,9 @@ describe("Initialization of the application", () => {
             circular: {
               active: false,
             },
+            deep: {
+              active: false,
+            },
             thirdparty: {
               active: false,
             },
@@ -176,6 +179,9 @@ describe("Initialization of the application", () => {
                 active: false,
               },
               circular: {
+                active: false,
+              },
+              deep: {
                 active: false,
               },
               thirdparty: {

--- a/apps/web/src/core/boostrap-app.spec.ts
+++ b/apps/web/src/core/boostrap-app.spec.ts
@@ -81,6 +81,7 @@ describe("Initialization of the application", () => {
       ui: {
         filters: storeDefaultValue.ui.filters,
         network: {
+          selectedNodeId: '',
           dependencies: {
             builtin: {
               active: false,
@@ -174,6 +175,7 @@ describe("Initialization of the application", () => {
         ui: {
           filters: storeDefaultValue.ui.filters,
           network: {
+            selectedNodeId: '',
             dependencies: {
               builtin: {
                 active: false,

--- a/apps/web/src/core/network/actions.ts
+++ b/apps/web/src/core/network/actions.ts
@@ -1,6 +1,7 @@
 import { NetworkLayout } from "@/store/state";
 
 export type NetworkActions =
+  | { action: "select_node"; payload: { nodeId: string, oldNodeId: string } }
   | { action: "toggle_deep"; payload: { enabled: boolean } }
   | { action: "toggle_circular"; payload: { enabled: boolean } }
   | { action: "toggle_builtin"; payload: { enabled: boolean } }

--- a/apps/web/src/core/network/actions.ts
+++ b/apps/web/src/core/network/actions.ts
@@ -1,6 +1,7 @@
 import { NetworkLayout } from "@/store/state";
 
 export type NetworkActions =
+  | { action: "toggle_deep"; payload: { enabled: boolean } }
   | { action: "toggle_circular"; payload: { enabled: boolean } }
   | { action: "toggle_builtin"; payload: { enabled: boolean } }
   | { action: "toggle_thirdparty"; payload: { enabled: boolean } }

--- a/apps/web/src/core/network/reducers.ts
+++ b/apps/web/src/core/network/reducers.ts
@@ -3,6 +3,19 @@ import * as Option from "@effect/data/Option";
 
 function toggleDependencies(): AppReducer {
   return function (event, state) {
+    if (event.action === "select_node") {
+      return Option.some({
+        data: state.data,
+        ui: {
+          ...state.ui,
+          network: {
+            ...state.ui.network,
+            selectedNodeId: event.payload.nodeId
+          },
+        },
+      });
+    }
+
     if (
       event.action === "toggle_deep" ||
       event.action === "toggle_circular" ||

--- a/apps/web/src/core/network/reducers.ts
+++ b/apps/web/src/core/network/reducers.ts
@@ -4,6 +4,7 @@ import * as Option from "@effect/data/Option";
 function toggleDependencies(): AppReducer {
   return function (event, state) {
     if (
+      event.action === "toggle_deep" ||
       event.action === "toggle_circular" ||
       event.action === "toggle_builtin" ||
       event.action === "toggle_thirdparty"

--- a/apps/web/src/core/network/select-node.spec.ts
+++ b/apps/web/src/core/network/select-node.spec.ts
@@ -1,0 +1,52 @@
+import { AppState, storeDefaultValue } from "@/store/state";
+import { AppStore } from "@/store/store";
+import { BehaviorSubject } from "rxjs";
+import { describe, expect, test } from "vitest";
+import { toPromise } from "../utils";
+import { networkReducers } from "./reducers";
+import { selectNode } from "./select-node";
+
+describe("When clicking on a node", () => {
+  test(`Should update selected nodeId`, async () => {
+    const appStore = new AppStore(
+      new BehaviorSubject<AppState>(storeDefaultValue),
+      networkReducers
+    );
+
+    const emittedEvents: string[] = [];
+    const subscription = appStore.events$.subscribe((events) => {
+      emittedEvents.push(events.action);
+    });
+
+    const dispatchAction = selectNode(appStore);
+
+    dispatchAction(['file-1.ts']);
+
+    const { ui: uiState1 } = await toPromise(appStore.store$);
+
+    expect(uiState1).toEqual({
+      ...storeDefaultValue.ui,
+      network: {
+        ...storeDefaultValue.ui.network,
+        selectedNodeId: 'file-1.ts'
+      },
+    });
+
+    dispatchAction(['file-2.ts']);
+
+    const { ui: uiState2 } = await toPromise(appStore.store$);
+
+    expect(uiState2).toEqual({
+      ...storeDefaultValue.ui,
+      network: {
+        ...storeDefaultValue.ui.network,
+        selectedNodeId: 'file-2.ts'
+      },
+    });
+
+    const appEvent = "select_node";
+    expect(emittedEvents).toEqual([appEvent, appEvent]);
+
+    subscription.unsubscribe();
+  });
+});

--- a/apps/web/src/core/network/select-node.ts
+++ b/apps/web/src/core/network/select-node.ts
@@ -1,0 +1,16 @@
+import { AppStore } from "@/store/store";
+
+export function selectNode(appStore: AppStore) {
+  return function (nodes: string[]) {
+    const { ui } = appStore.getState();
+    appStore.dispatch({
+      action: "select_node",
+      payload: {
+        nodeId: nodes.length > 0 ? nodes[0] : "",
+        oldNodeId: ui.network.selectedNodeId
+      },
+    }, {
+      notify: true
+    });
+  };
+}

--- a/apps/web/src/core/network/toggle-dependencies.spec.ts
+++ b/apps/web/src/core/network/toggle-dependencies.spec.ts
@@ -8,6 +8,7 @@ import { networkReducers } from "./reducers";
 
 describe("When interacting with network dependencies", () => {
   describe.each([
+    { target: "deep" },
     { target: "circular" },
     { target: "builtin" },
     { target: "thirdparty" },

--- a/apps/web/src/core/network/toggle-dependencies.ts
+++ b/apps/web/src/core/network/toggle-dependencies.ts
@@ -1,7 +1,7 @@
 import { AppStore } from "@/store/store";
 
 export function toggleDependencies(appStore: AppStore) {
-  return function (params: { target: "circular" | "builtin" | "thirdparty" }) {
+  return function (params: { target: "deep" | "circular" | "builtin" | "thirdparty" }) {
     const networkDependency =
       appStore.getState().ui.network.dependencies[params.target];
 

--- a/apps/web/src/network/Network.tsx
+++ b/apps/web/src/network/Network.tsx
@@ -279,16 +279,15 @@ export default function GraphNetwork() {
 
     _network.on('click', (params) => {
       const { ui, data } = appStore.getState();
-      if (params.nodes.length > 0) {
+      if (ui.network.dependencies.deep.active) {
         highlightDeepDependencies(data, ui.network.selectedNodeId, false);
-        const nodeId = params.nodes[0]
-        if (ui.network.dependencies.deep.active) {
+        if (params.nodes.length > 0) {
+          const nodeId = params.nodes[0]
           highlightDeepDependencies(data, nodeId, true);
           ui.network.selectedNodeId = nodeId
-        } else ui.network.selectedNodeId = ''
-      } else {
-        highlightDeepDependencies(data, ui.network.selectedNodeId, false);
-        ui.network.selectedNodeId = ''
+        } else {
+          ui.network.selectedNodeId = ''
+        }
       }
     })
     setNetwork(_network);

--- a/apps/web/src/network/Network.tsx
+++ b/apps/web/src/network/Network.tsx
@@ -34,6 +34,7 @@ import { ProgressLoader } from "@/network/ProgressLoader";
 import { AppEffects, callUseCase, notify } from "@/store/store";
 import { updateConfiguration } from "@/core/network/update-configuration";
 import { storeDefaultValue } from "@/store/state";
+import { selectNode } from "@/core/network/select-node";
 
 export default function GraphNetwork() {
   const appStore = useAppStore();
@@ -289,18 +290,7 @@ export default function GraphNetwork() {
     });
 
 
-    _network.on('click', (params) => {
-      const { ui } = appStore.getState();
-      appStore.dispatch({
-        action: "select_node",
-        payload: {
-          nodeId: params.nodes.length > 0 ? params.nodes[0] : "",
-          oldNodeId: ui.network.selectedNodeId
-        },
-      }, {
-        notify: true
-      });
-    })
+    _network.on('click', (params) => selectNode(appStore)(params.nodes))
     setNetwork(_network);
     reconciliateNetwork(_network);
   }

--- a/apps/web/src/network/Network.tsx
+++ b/apps/web/src/network/Network.tsx
@@ -204,7 +204,6 @@ export default function GraphNetwork() {
               highlightDeepDependencies(data, appEvents.payload.nodeId, true);
             }
           }
-          ui.network.selectedNodeId = appEvents.payload.nodeId
         }
         break;
       }

--- a/apps/web/src/network/dependencies.ts
+++ b/apps/web/src/network/dependencies.ts
@@ -21,6 +21,24 @@ export const circularEdgeOptions = {
   inherit: false,
 };
 
+export const deepDependencyNodeOptions = {
+  color: {
+    border: "#000000",
+    background: "#73e6ac",
+    highlight: {
+      border: "#000000",
+      background: "#73e6ac",
+    },
+  },
+};
+
+export const deepDependencyEdgeOptions = {
+  color: "#73e6ac",
+  highlight: "#DF0000",
+  hover: "#DF0000",
+  inherit: false,
+};
+
 export const builtinNodeOptions = {
   color: {
     border: "#000000",

--- a/apps/web/src/sidebar/dependencies/Dependencies.tsx
+++ b/apps/web/src/sidebar/dependencies/Dependencies.tsx
@@ -38,7 +38,6 @@ export function Dependencies() {
         <Box p="md">
           <Checkbox
             label="Deep dependencies"
-            disabled={state.data.cycles.length === 0}
             radius="md"
             color="cyan"
             checked={network?.dependencies.deep.active ?? false}

--- a/apps/web/src/sidebar/dependencies/Dependencies.tsx
+++ b/apps/web/src/sidebar/dependencies/Dependencies.tsx
@@ -40,6 +40,7 @@ export function Dependencies() {
             label="Deep dependencies"
             radius="md"
             color="cyan"
+            disabled={network?.dependencies.circular.active}
             checked={network?.dependencies.deep.active ?? false}
             onChange={() => {
               toggleDepsVisualizationOption("deep");
@@ -49,7 +50,7 @@ export function Dependencies() {
         <Box p="md">
           <Checkbox
             label="Circular dependencies"
-            disabled={state.data.cycles.length === 0}
+            disabled={state.data.cycles.length === 0 || network?.dependencies.deep.active}
             radius="md"
             color="red"
             checked={network?.dependencies.circular.active ?? false}

--- a/apps/web/src/sidebar/dependencies/Dependencies.tsx
+++ b/apps/web/src/sidebar/dependencies/Dependencies.tsx
@@ -24,7 +24,7 @@ export function Dependencies() {
   };
 
   function toggleDepsVisualizationOption(
-    option: "circular" | "thirdparty" | "builtin"
+    option: "deep" | "circular" | "thirdparty" | "builtin"
   ) {
     const invokeUseCase = callUseCase(toggleDependencies);
     invokeUseCase({ target: option });
@@ -35,6 +35,18 @@ export function Dependencies() {
       <Navbar.Section>
         <Box p="md">Dependencies visualization</Box>
 
+        <Box p="md">
+          <Checkbox
+            label="Deep dependencies"
+            disabled={state.data.cycles.length === 0}
+            radius="md"
+            color="cyan"
+            checked={network?.dependencies.deep.active ?? false}
+            onChange={() => {
+              toggleDepsVisualizationOption("deep");
+            }}
+          />
+        </Box>
         <Box p="md">
           <Checkbox
             label="Circular dependencies"

--- a/apps/web/src/store/state.ts
+++ b/apps/web/src/store/state.ts
@@ -22,6 +22,9 @@ export interface UiState {
   };
   network: {
     dependencies: {
+      deep: {
+        active: boolean;
+      };
       circular: {
         active: boolean;
       };
@@ -70,6 +73,9 @@ export const storeDefaultValue = {
     },
     network: {
       dependencies: {
+        deep: {
+          active: false
+        },
         circular: {
           active: false,
         },

--- a/apps/web/src/store/state.ts
+++ b/apps/web/src/store/state.ts
@@ -21,6 +21,7 @@ export interface UiState {
     glob: string;
   };
   network: {
+    selectedNodeId: string,
     dependencies: {
       deep: {
         active: boolean;
@@ -72,6 +73,7 @@ export const storeDefaultValue = {
       glob: "",
     },
     network: {
+      selectedNodeId: '',
       dependencies: {
         deep: {
           active: false


### PR DESCRIPTION
closes #179

## Summary
Allow highlighting deep dependency sub-graph of a file that is selected:

https://github.com/user-attachments/assets/16f4e8fa-c695-4473-894b-e853be0504b3

This is still Work In Progress.

## Implementation

Implementation overview:
- Add new `deepDependencyNodeOptions` and `deepDependencyEdgeOptions` to highlight nodes and edges.
- Add `toggle_deep` NetworkAction, new network state in store and checkbox to trigger option.
- Created `highlightDeepDependencies` function to highlight deep dependencies using DFS.
- Add listener `_network.on('click', ...)` for `viz-network` to trigger dependency highlighting.
- `oldNodeId` is used to reset highlighting of previously selected node.

Alternative UX:
- Could highlight deep dependencies when `focus_on_node`. But `click` event provides faster feedback.

Bugs:
- [x] The highlight will override `Circular dependencies` - fixing would require huge changes  to how rendering works.

Performance:
- [ ] Could create a diffing function between old dependency graph and new one to optimise rendering speed.

## Testing

- [x] Unit tests updated for new default store

## Impacted documentation

- [x] Changesets were generated using `pnpm changeset` at the root of the workspace, affected packages are being bumped (either patch/minor) and a clear description for each of the affected packages was added.
