### PR TITLE
FIX: Only match path alias once per moduleDeclaration

### DIFF
--- a/packages/skott/src/modules/walkers/ecmascript/typescript/path-alias.ts
+++ b/packages/skott/src/modules/walkers/ecmascript/typescript/path-alias.ts
@@ -1,7 +1,7 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 
-import { pipe, Option } from "effect";
+import { Option, pipe } from "effect";
 import JSON5 from "json5";
 import type { CompilerOptions } from "typescript";
 
@@ -32,9 +32,11 @@ function resolveAliasToRelativePath(
       `Extracting "${moduleDeclaration}" base path using path alias base directory "${baseAliasDirname}"`
     );
 
-    const modulePathWithoutAliasBaseDirname = moduleDeclaration.split(
-      baseAliasDirname.concat("/")
-    )[1];
+    const baseDirWithSlash = baseAliasDirname.concat("/");
+    const startIndex =
+      moduleDeclaration.indexOf(baseDirWithSlash) + baseDirWithSlash.length;
+    const modulePathWithoutAliasBaseDirname =
+      moduleDeclaration.substring(startIndex);
 
     logger.info(
       `Attempt to map alias path to real file-system path.` +


### PR DESCRIPTION
This PR resolves a bug when working with path aliases in a tsconfig.

Currently, the logic for replacing the a path alias splits on the alias, and get's the second array index as the "rest of the path", however, if the path alias exists twice or more in the original path, then this results in missing part of the path.

## Example
Actual:
`/components/example/components/test` -> `/src/components/example`

Expected:
`/components/example/components/test` -> `/src/components/example/components/test`

---

I've also added test cases for this particular case now.

The tests for some cli and watch mode tests are failing locally for me, although these were failing when I pulled main, so I don't believe they are related.