### PR TITLE
chore: relax runtime dependency ranges for published packages

### DIFF
--- a/.changeset/nervous-ways-destroy.md
+++ b/.changeset/nervous-ways-destroy.md
@@ -1,0 +1,6 @@
+---
+"remote-tarball-fetcher": patch
+"skott": patch
+---
+
+Relax runtime dependency ranges to allow compatible updates and security fixes

--- a/packages/remote-tarball-fetcher/package.json
+++ b/packages/remote-tarball-fetcher/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@effect/schema": "^0.67.23",
-    "effect": "3.3.2",
+    "effect": "^3.3.2",
     "semver": "^7.5.3",
     "tar": "^6.1.15",
     "unzipper": "^0.10.14"

--- a/packages/skott/package.json
+++ b/packages/skott/package.json
@@ -45,16 +45,16 @@
     "test:integration:watch": "vitest --watch --config=test/vitest.integration.js"
   },
   "dependencies": {
-    "@parcel/watcher": "2.5.4",
-    "@typescript-eslint/typescript-estree": "8.53.0",
+    "@parcel/watcher": "^2.5.4",
+    "@typescript-eslint/typescript-estree": "^8.53.0",
     "commander": "^11.0.0",
     "compression": "^1.7.4",
-    "depcheck": "1.4.7",
-    "digraph-js": "2.2.4",
+    "depcheck": "^1.4.7",
+    "digraph-js": "^2.2.4",
     "effect": "^3.20.0",
     "estree-walker": "^3.0.3",
-    "fp-ts": "2.5.0",
-    "fs-tree-structure": "workspace:*",
+    "fp-ts": "^2.5.0",
+    "fs-tree-structure": "workspace:^",
     "ignore-walk": "^6.0.3",
     "io-ts": "^2.2.20",
     "is-wsl": "^3.0.0",
@@ -68,7 +68,7 @@
     "polka": "^0.5.2",
     "sirv": "^2.0.3",
     "skott-webapp": "workspace:^",
-    "typescript": "5.9.3"
+    "typescript": "^5.9.3"
   },
   "devDependencies": {
     "@nodesecure/eslint-config": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,10 +204,10 @@ importers:
     dependencies:
       '@effect/schema':
         specifier: ^0.67.23
-        version: 0.67.23(effect@3.3.2)
+        version: 0.67.23(effect@3.21.0)
       effect:
-        specifier: 3.3.2
-        version: 3.3.2
+        specifier: ^3.3.2
+        version: 3.21.0
       semver:
         specifier: ^7.5.3
         version: 7.5.3
@@ -276,10 +276,10 @@ importers:
   packages/skott:
     dependencies:
       '@parcel/watcher':
-        specifier: 2.5.4
+        specifier: ^2.5.4
         version: 2.5.4
       '@typescript-eslint/typescript-estree':
-        specifier: 8.53.0
+        specifier: ^8.53.0
         version: 8.53.0(typescript@5.9.3)
       commander:
         specifier: ^11.0.0
@@ -288,10 +288,10 @@ importers:
         specifier: ^1.7.4
         version: 1.7.4
       depcheck:
-        specifier: 1.4.7
+        specifier: ^1.4.7
         version: 1.4.7
       digraph-js:
-        specifier: 2.2.4
+        specifier: ^2.2.4
         version: 2.2.4
       effect:
         specifier: ^3.20.0
@@ -300,10 +300,10 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       fp-ts:
-        specifier: 2.5.0
+        specifier: ^2.5.0
         version: 2.5.0
       fs-tree-structure:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../fs-tree-structure
       ignore-walk:
         specifier: ^6.0.3
@@ -345,7 +345,7 @@ importers:
         specifier: workspace:^
         version: link:../../apps/web
       typescript:
-        specifier: 5.9.3
+        specifier: ^5.9.3
         version: 5.9.3
     devDependencies:
       '@nodesecure/eslint-config':
@@ -575,7 +575,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.24.0
-      '@babel/types': 7.24.5
+      '@babel/types': 7.28.6
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
@@ -594,7 +594,7 @@ packages:
     resolution: {integrity: sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.5
+      '@babel/types': 7.28.6
     dev: true
 
   /@babel/helper-module-transforms@7.22.5:
@@ -643,7 +643,7 @@ packages:
     resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.5
+      '@babel/types': 7.28.6
     dev: true
 
   /@babel/helper-split-export-declaration@7.22.5:
@@ -657,7 +657,7 @@ packages:
     resolution: {integrity: sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.5
+      '@babel/types': 7.28.6
 
   /@babel/helper-string-parser@7.22.5:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
@@ -670,7 +670,6 @@ packages:
   /@babel/helper-string-parser@7.27.1:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helper-validator-identifier@7.22.5:
     resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
@@ -683,7 +682,6 @@ packages:
   /@babel/helper-validator-identifier@7.28.5:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helper-validator-option@7.22.5:
     resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
@@ -748,6 +746,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.24.5
+    dev: true
 
   /@babel/parser@7.28.6:
     resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
@@ -755,7 +754,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.28.6
-    dev: false
 
   /@babel/plugin-transform-react-jsx-self@7.24.5(@babel/core@7.24.5):
     resolution: {integrity: sha512-RtCJoUO2oYrYwFPtR1/jkoBEcFuI1ae9a9IMxeyAVa3a1Ap4AnxmyIKG2b2FaJKqkidw/0cxRbWN+HOs6ZWd1w==}
@@ -798,7 +796,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.24.2
-      '@babel/parser': 7.24.5
+      '@babel/parser': 7.28.6
       '@babel/types': 7.24.5
 
   /@babel/traverse@7.22.5:
@@ -829,9 +827,9 @@ packages:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.24.5
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.5
-      debug: 4.3.4
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -858,7 +856,6 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-    dev: false
 
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
@@ -1074,12 +1071,12 @@ packages:
     resolution: {integrity: sha512-FdQ0qbYL7t+GP5eWdAPC+oeN2w3zqnujrdDLp/sj58UtMxFSHg21crprmbmiAJAWsL5EdB9aZzcisBGn382xHg==}
     dev: true
 
-  /@effect/schema@0.67.23(effect@3.3.2):
+  /@effect/schema@0.67.23(effect@3.21.0):
     resolution: {integrity: sha512-REKPOCm8guN6CEMvlQfR5ovjldeVRSnf3sj8FhyOIOeWuUtWlqghyBtgXLbAniSkjFFMFxWwDFyAoxVX9C0wGw==}
     peerDependencies:
       effect: ^3.3.2
     dependencies:
-      effect: 3.3.2
+      effect: 3.21.0
       fast-check: 3.19.0
     dev: false
 
@@ -2765,10 +2762,10 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.61.0
       '@typescript-eslint/visitor-keys': 5.61.0
-      debug: 4.3.4
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.2
+      semver: 7.7.3
       tsutils: 3.21.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -2786,10 +2783,10 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.61.0
       '@typescript-eslint/visitor-keys': 5.61.0
-      debug: 4.3.4
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.2
+      semver: 7.7.3
       tsutils: 3.21.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3835,17 +3832,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      '@babel/parser': 7.24.5
+      '@babel/parser': 7.28.6
       '@babel/traverse': 7.24.5
       '@vue/compiler-sfc': 3.5.26
       callsite: 1.0.0
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
-      debug: 4.3.4
+      debug: 4.4.3
       deps-regex: 0.2.0
       findup-sync: 5.0.0
       ignore: 5.3.1
-      is-core-module: 2.12.1
+      is-core-module: 2.16.1
       js-yaml: 3.14.1
       json5: 2.2.3
       lodash: 4.17.21
@@ -3856,7 +3853,7 @@ packages:
       require-package-name: 2.0.1
       resolve: 1.22.11
       resolve-from: 5.0.0
-      semver: 7.6.2
+      semver: 7.7.3
       yargs: 16.2.0
     transitivePeerDependencies:
       - supports-color
@@ -3955,10 +3952,6 @@ packages:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
-    dev: false
-
-  /effect@3.3.2:
-    resolution: {integrity: sha512-695XQBtp+UUYG50oREG9ujnRoeQU7xhwHDhT6ZAexm3Q+umdml1kjxcPoYRrS65crmaLlhVpjZHePJNzWOODnA==}
     dev: false
 
   /electron-to-chromium@1.4.439:
@@ -4749,6 +4742,7 @@ packages:
 
   /function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -4983,6 +4977,7 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+    dev: true
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -5167,6 +5162,7 @@ packages:
     resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
     dependencies:
       has: 1.0.3
+    dev: true
 
   /is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -6654,6 +6650,7 @@ packages:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
     hasBin: true
+    dev: true
 
   /semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}


### PR DESCRIPTION
## Summary

This PR relaxes pinned runtime dependency versions in published packages so `skott` consumers can receive compatible updates and security fixes without waiting for another release.

For example, this is the kind of issue reported in [#199](https://github.com/antoine-coulon/skott/issues/199), where `skott` was pinning an old `effect` version with a security issue.

## Implementation

- changed pinned runtime dependencies to caret ranges in `packages/skott` and `packages/remote-tarball-fetcher`
- changed `fs-tree-structure` from `workspace:*` to `workspace:^` in `packages/skott` so the published manifest keeps a semver range
- left `devDependencies` unchanged to keep the review focused on published runtime dependencies

No public API or behavior changes are expected.

## Testing

- `pnpm --filter fs-tree-structure test`
- `pnpm --filter remote-tarball-fetcher test`
- `pnpm --filter skott build`
- `pnpm --filter skott typecheck`

- [ ] Unit tests were added to cover the new feature or bug fix (+ eventually integration tests, but unit should be preferred whenever its possible).

## Impacted documentation

- [x] Changesets were generated using `pnpm changeset` at the root of the workspace, affected packages are being bumped (either patch/minor) and a clear description for each of the affected packages was added.
