### PR TITLE
fix(path-alias): resolve relative tsconfig extends against declaring file's directory

### DIFF
--- a/packages/skott/src/modules/walkers/ecmascript/typescript/path-alias.ts
+++ b/packages/skott/src/modules/walkers/ecmascript/typescript/path-alias.ts
@@ -63,19 +63,25 @@ function isRootAliasSymbol(segment: string): boolean {
   return !segment.includes("/");
 }
 
+interface ReadTSConfigResult {
+  config: SupportedTSConfig;
+  resolvedPath: string;
+}
+
 async function readTSConfig(
   tsConfigPath: string,
   logger: Logger,
   fileReader: FileReader
-): Promise<SupportedTSConfig> {
+): Promise<ReadTSConfigResult> {
   let tsconfig = "";
+  let resolvedPath = "";
 
   try {
-    const localTSConfigPath = path.join(
-      fileReader.getCurrentWorkingDir(),
-      tsConfigPath
-    );
+    const localTSConfigPath = path.isAbsolute(tsConfigPath)
+      ? tsConfigPath
+      : path.join(fileReader.getCurrentWorkingDir(), tsConfigPath);
     tsconfig = await fileReader.read(localTSConfigPath);
+    resolvedPath = localTSConfigPath;
     logger.success(`Successfully found tsconfig: ${localTSConfigPath}`);
   } catch (exception: any) {
     logger.failure(
@@ -93,6 +99,7 @@ async function readTSConfig(
         paths: [fileReader.getCurrentWorkingDir()]
       });
       tsconfig = await fileReader.read(thirdPartyTSConfigPath);
+      resolvedPath = thirdPartyTSConfigPath;
 
       logger.success(
         `Successfully found tsconfig at: ${thirdPartyTSConfigPath}`
@@ -104,19 +111,36 @@ async function readTSConfig(
     }
   }
 
-  return JSON5.parse<SupportedTSConfig>(tsconfig);
+  return { config: JSON5.parse<SupportedTSConfig>(tsconfig), resolvedPath };
 }
 
 export async function buildPathAliases(
   fileReader: FileReader,
   tsConfigPath: string,
   aliasLinks: Map<string, string>,
-  logger: Logger
+  logger: Logger,
+  visitedConfigs: Set<string> = new Set()
 ): Promise<TSConfig> {
   try {
     logger.info(`Reading from tsconfig: ${tsConfigPath}`);
 
-    const tsConfig = await readTSConfig(tsConfigPath, logger, fileReader);
+    const { config: tsConfig, resolvedPath } = await readTSConfig(
+      tsConfigPath,
+      logger,
+      fileReader
+    );
+
+    // Guard against circular extends chains (e.g. caused by skott resolving
+    // a relative path inside a node_modules package against CWD instead of
+    // against the package directory, which can loop back to the root config).
+    if (resolvedPath && visitedConfigs.has(resolvedPath)) {
+      logger.info(`Skipping already-visited tsconfig: ${resolvedPath}`);
+      return {};
+    }
+    if (resolvedPath) {
+      visitedConfigs.add(resolvedPath);
+    }
+
     const baseUrl = tsConfig.compilerOptions?.baseUrl ?? ".";
 
     const paths: Record<string, string[]> =
@@ -154,11 +178,23 @@ export async function buildPathAliases(
     if (extendedTsConfigPath) {
       logger.info(`Found tsconfig extension: ${extendedTsConfigPath}`);
 
+      // Relative extends paths must be resolved relative to the directory of
+      // the tsconfig that declares them, not relative to CWD. Without this,
+      // a package in node_modules that uses a relative extends (e.g.
+      // `@vue/tsconfig/tsconfig.dom.json` extends `./tsconfig.json`) would be
+      // resolved against CWD, looping back to the project root config.
+      const resolvedExtendedPath = extendedTsConfigPath.startsWith(".")
+        ? path.isAbsolute(resolvedPath)
+          ? path.resolve(path.dirname(resolvedPath), extendedTsConfigPath)
+          : path.join(path.dirname(resolvedPath), extendedTsConfigPath)
+        : extendedTsConfigPath;
+
       await buildPathAliases(
         fileReader,
-        extendedTsConfigPath,
+        resolvedExtendedPath,
         aliasLinks,
-        logger
+        logger,
+        visitedConfigs
       );
 
       logger.success(

--- a/packages/skott/test/unit/ecmascript/typescript.spec.ts
+++ b/packages/skott/test/unit/ecmascript/typescript.spec.ts
@@ -1363,6 +1363,62 @@ describe("When traversing a TypeScript project", () => {
             });
           });
         });
+
+        describe("When a tsconfig in a subdirectory uses a relative extends that would loop back to the root config", () => {
+          it("should resolve path aliases from the correct sibling config without infinite loop", async () => {
+            // Reproduces the @vue/tsconfig pattern:
+            //   tsconfig.json           extends ./subpackage/tsconfig.dom.json
+            //   subpackage/tsconfig.dom.json  extends ./tsconfig.json  <-- means its sibling
+            //   subpackage/tsconfig.json      defines the path aliases
+            //
+            // Without the fix, `./tsconfig.json` inside subpackage/tsconfig.dom.json
+            // was resolved against CWD and landed on the root tsconfig, causing an
+            // infinite extends loop. With the fix it resolves to the sibling file.
+            const tsConfigAliases = {
+              compilerOptions: {
+                paths: {
+                  "@path-alias": ["path/alias/index.ts"]
+                }
+              }
+            };
+            const tsConfigDom = {
+              extends: "./tsconfig.json"
+            };
+            const tsConfigRoot = {
+              extends: "./subpackage/tsconfig.dom.json"
+            };
+
+            mountFakeFileSystem({
+              "main/app/index.ts": `
+                import "@path-alias";
+              `,
+              "path/alias/index.ts": `
+                export function something() {}
+              `,
+              "subpackage/tsconfig.json": JSON.stringify(tsConfigAliases),
+              "subpackage/tsconfig.dom.json": JSON.stringify(tsConfigDom),
+              "tsconfig.json": JSON.stringify(tsConfigRoot)
+            });
+
+            const { graph } = await buildSkottProjectUsingInMemoryFileExplorer({
+              trackThirdParty: true,
+              tsConfigPath: "tsconfig.json"
+            });
+
+            expect(graph).to.be.deep.equal({
+              "main/app/index.ts": {
+                adjacentTo: ["path/alias/index.ts"],
+                id: "main/app/index.ts",
+                body: fakeNodeBody
+              },
+              "path/alias/index.ts": {
+                id: "path/alias/index.ts",
+                adjacentTo: [],
+                body: fakeNodeBody
+              }
+            });
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
## Problem

When a `tsconfig.json` extends a package from `node_modules` that itself uses a **relative `extends`** internally, skott enters an **infinite loop** and never terminates.

The most common real-world trigger is [`@vue/tsconfig`](https://github.com/vuejs/tsconfig) — the officially recommended TypeScript base for Vue 3 projects. Its `tsconfig.dom.json` contains `"extends": "./tsconfig.json"`, which is meant to extend its **sibling** inside the package directory. TypeScript resolves this correctly. Skott does not: it resolves the relative path against CWD, landing on the project-root config, which extends `@vue/tsconfig/tsconfig.dom.json` again → infinite loop.

```
Reading from tsconfig: @vue/tsconfig/tsconfig.dom.json
Found tsconfig extension: ./tsconfig.json
Reading from tsconfig: ./tsconfig.json          ← resolved against CWD (wrong)
✓ Successfully found tsconfig: /project/tsconfig.json
Found tsconfig extension: @vue/tsconfig/tsconfig.dom.json
... (repeats forever)
```

Closes #210. Also fixes #177. Related: #142.

## Root cause

In `buildPathAliases`, the raw `extends` string is passed directly to the recursive call. In `readTSConfig` it is then joined against `fileReader.getCurrentWorkingDir()` — always the project root — instead of against the **directory of the tsconfig file that declared the extends**.

## Fix

Two changes in `src/modules/walkers/ecmascript/typescript/path-alias.ts`:

1. **`readTSConfig` now returns the resolved path** alongside the parsed config — the CWD-relative path from the direct-read attempt, and the absolute path from `require.resolve` for third-party packages.

2. **`buildPathAliases` resolves relative extends against the declaring file's directory.** When `resolvedPath` is relative, `path.join(path.dirname(resolvedPath), extends)` is used (preserves the relative form, so in-memory file readers used in tests continue to work). When `resolvedPath` is absolute (real `node_modules` path), `path.resolve(path.dirname(resolvedPath), extends)` is used.

3. **A visited-configs `Set` is threaded through recursive calls** as a safety net: if a config path is visited twice the recursion stops immediately with a log message, so any edge case that still produces a cycle cannot loop forever.

## Tests

A new unit test covers the exact pattern: a tsconfig in a subdirectory uses `"extends": "./tsconfig.json"` to extend its sibling, while the root config extends that subdirectory config. Without the fix the test loops indefinitely (vitest timeout); with the fix it terminates and correctly resolves the path aliases from the sibling config.

All **140 unit tests pass**. The failing integration tests (`cli.spec.ts` watch-mode, `runner.spec.ts`) are **pre-existing** — they require a compiled `dist/bin/cli.js` that is absent from a fresh clone and are unrelated to this change.
